### PR TITLE
fix: Issue #5 ログインボタン500エラー修正

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,39 @@
+// APIクライアント
+// 修正: APIコール失敗時に undefined を返す代わりに Error をスローするよう変更。
+//       呼び出し元が try/catch でエラーを確実に検知できるようにする。
+
+import { LoginRequest, LoginResponse } from '../types/auth';
+
+const API_BASE_URL = process.env.API_BASE_URL ?? 'https://api.example.com';
+
+/**
+ * ログインAPIを呼び出す。
+ * 成功時は LoginResponse を返す。
+ * 失敗時（ネットワークエラー・認証エラー・サーバーエラー等）は Error をスローする。
+ *
+ * @throws {Error} ネットワークエラーまたはHTTPエラー
+ */
+export async function callLoginApi(request: LoginRequest): Promise<LoginResponse> {
+  let response: Response;
+
+  try {
+    response = await fetch(`${API_BASE_URL}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+  } catch (networkError) {
+    // ネットワーク障害時: undefined を返さず例外をスローする
+    throw new Error(
+      `ネットワークエラーが発生しました: ${networkError instanceof Error ? networkError.message : String(networkError)}`
+    );
+  }
+
+  if (!response.ok) {
+    // HTTPエラー（4xx / 5xx）時: undefined を返さず例外をスローする
+    throw new Error(`ログインAPIエラー: HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const data: LoginResponse = await response.json();
+  return data;
+}

--- a/src/auth/login.test.ts
+++ b/src/auth/login.test.ts
@@ -1,0 +1,117 @@
+/**
+ * src/auth/login.ts の再現テスト
+ *
+ * テスト方針（修正方針より）:
+ *  - 再現テスト  : 誤った認証情報でログインしてもクラッシュしないこと
+ *  - 正常系テスト: 正しい認証情報でログインしトークンが返ること
+ *  - ネットワーク異常テスト: ネットワーク障害時もアプリがクラッシュしないこと
+ *  - リグレッションテスト: callLoginApi のモック差し替えによる影響確認
+ */
+
+import { login } from './login';
+import * as client from '../api/client';
+
+// callLoginApi をモック化して外部通信なしにテストする
+jest.mock('../api/client');
+const mockCallLoginApi = client.callLoginApi as jest.MockedFunction<typeof client.callLoginApi>;
+
+describe('login()', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // 再現テスト: 修正前は response が undefined のとき TypeError が発生していた
+  // -----------------------------------------------------------------------
+  describe('再現テスト: APIがエラーを返す場合', () => {
+    it('認証失敗（401相当）のとき TypeError をスローせず失敗結果を返す', async () => {
+      mockCallLoginApi.mockRejectedValue(new Error('ログインAPIエラー: HTTP 401 Unauthorized'));
+
+      const result = await login('wrong@example.com', 'wrongpassword');
+
+      expect(result.success).toBe(false);
+      expect(result.errorMessage).toMatch(/401/);
+      expect(result.token).toBeUndefined();
+    });
+
+    it('サーバーエラー（500相当）のとき TypeError をスローせず失敗結果を返す', async () => {
+      mockCallLoginApi.mockRejectedValue(new Error('ログインAPIエラー: HTTP 500 Internal Server Error'));
+
+      const result = await login('user@example.com', 'password');
+
+      expect(result.success).toBe(false);
+      expect(result.errorMessage).toMatch(/500/);
+    });
+
+    it('APIが token のない空オブジェクトを返した場合も TypeError をスローしない', async () => {
+      // 型エラーを回避しつつ、実行時に token が欠落している状況を再現する
+      mockCallLoginApi.mockResolvedValue({ token: '', userId: 'u1', expiresAt: '' });
+
+      const result = await login('user@example.com', 'password');
+
+      // token が空文字（falsy）の場合もガード節で弾かれること
+      expect(result.success).toBe(false);
+      expect(result.errorMessage).toContain('有効なトークン');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ネットワーク異常テスト
+  // -----------------------------------------------------------------------
+  describe('ネットワーク異常テスト', () => {
+    it('ネットワーク障害時にアプリがクラッシュせず適切なエラーメッセージを返す', async () => {
+      mockCallLoginApi.mockRejectedValue(new Error('ネットワークエラーが発生しました: Failed to fetch'));
+
+      const result = await login('user@example.com', 'password');
+
+      expect(result.success).toBe(false);
+      expect(result.errorMessage).toMatch(/ネットワーク/);
+    });
+
+    it('非 Error オブジェクトがスローされた場合もクラッシュしない', async () => {
+      mockCallLoginApi.mockRejectedValue('unexpected string error');
+
+      const result = await login('user@example.com', 'password');
+
+      expect(result.success).toBe(false);
+      expect(result.errorMessage).toBeDefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 正常系テスト
+  // -----------------------------------------------------------------------
+  describe('正常系テスト', () => {
+    it('正しい認証情報でログインするとトークンを含む成功結果を返す', async () => {
+      mockCallLoginApi.mockResolvedValue({
+        token: 'valid-jwt-token',
+        userId: 'user-123',
+        expiresAt: '2026-12-31T23:59:59Z',
+      });
+
+      const result = await login('user@example.com', 'correctpassword');
+
+      expect(result.success).toBe(true);
+      expect(result.token).toBe('valid-jwt-token');
+      expect(result.errorMessage).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // リグレッションテスト: callLoginApi の引数が正しく渡されているか
+  // -----------------------------------------------------------------------
+  describe('リグレッションテスト', () => {
+    it('login() が callLoginApi に正しい email と password を渡す', async () => {
+      mockCallLoginApi.mockResolvedValue({
+        token: 'tok',
+        userId: 'u1',
+        expiresAt: '2026-01-01T00:00:00Z',
+      });
+
+      await login('test@example.com', 'mypassword');
+
+      expect(mockCallLoginApi).toHaveBeenCalledTimes(1);
+      expect(mockCallLoginApi).toHaveBeenCalledWith({ email: 'test@example.com', password: 'mypassword' });
+    });
+  });
+});

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -1,0 +1,47 @@
+// ログイン処理
+// 修正: APIレスポンスが undefined / null の場合に .token アクセスで TypeError が発生していたバグを修正。
+//       callLoginApi が失敗時に例外をスローするようになったため、try/catch でエラーを捕捉し、
+//       ガード節によって response および response.token の存在を確認してからアクセスする。
+
+import { callLoginApi } from '../api/client';
+import { LoginRequest, LoginResponse } from '../types/auth';
+
+export interface LoginResult {
+  success: boolean;
+  token?: string;
+  errorMessage?: string;
+}
+
+/**
+ * メールアドレスとパスワードでログインを行う。
+ * APIレスポンスが不正な場合や通信エラー時も安全に処理し、
+ * TypeError: Cannot read property 'token' of undefined が発生しないようにする。
+ */
+export async function login(email: string, password: string): Promise<LoginResult> {
+  const request: LoginRequest = { email, password };
+
+  let response: LoginResponse;
+
+  try {
+    response = await callLoginApi(request);
+  } catch (error) {
+    // ネットワークエラー・HTTPエラー時のハンドリング
+    const message = error instanceof Error ? error.message : 'ログイン中に予期しないエラーが発生しました。';
+    return { success: false, errorMessage: message };
+  }
+
+  // --- ここが修正箇所 (L42相当) ---
+  // 修正前: const token = response.token;  // response が undefined の場合に TypeError
+  // 修正後: response および token の存在をガード節で確認してからアクセスする
+
+  if (!response || !response.token) {
+    return {
+      success: false,
+      errorMessage: 'ログインAPIから有効なトークンが返されませんでした。',
+    };
+  }
+
+  const token = response.token;
+
+  return { success: true, token };
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,21 @@
+// 認証関連の型定義
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+/**
+ * LoginResponse の token は必須フィールドとして定義する。
+ * API失敗時はこの型のオブジェクトを返さず、呼び出し元で例外をキャッチする設計とする。
+ */
+export interface LoginResponse {
+  token: string;
+  userId: string;
+  expiresAt: string;
+}
+
+export interface AuthError {
+  code: string;
+  message: string;
+}


### PR DESCRIPTION
## 修正内容
Issue #5 のバグ修正です。

## 修正方針 (承認済み)
---
🔍 **修正方針 (AI分析)**

**原因:** `src/auth/login.ts:42` にて、APIレスポンスオブジェクトが `undefined` の状態で `.token` プロパティへアクセスしているため、`TypeError: Cannot read property 'token' of undefined` が発生しています。`src/api/client.ts` のAPIクライアントが、ログインAPIの呼び出し失敗時（ネットワークエラー・認証失敗・サーバーエラー等）に `undefined` を返しているにも関わらず、`login.ts` 側でレスポンスの存在チェックを行っていないことが根本原因と考えられます。

**発生条件:**
- ログインAPIへのリクエストが失敗または空レスポンスを返した場合（例: 認証情報不一致、サーバー側500エラー、ネットワーク障害）
- `src/api/client.ts` が例外をキャッチして `undefined` / `null` を返す実装になっている場合
- `src/types/auth.ts` の型定義

AI Agent が自動修正しました。