### PR TITLE
feat: Issue #7 メールバリデーション追加

### DIFF
--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import { validateEmail } from "../utils/validate";
+
+interface RegisterFormValues {
+  email: string;
+}
+
+interface FieldError {
+  email?: string;
+}
+
+export function RegisterForm() {
+  const [values, setValues] = useState<RegisterFormValues>({ email: "" });
+  const [errors, setErrors] = useState<FieldError>({});
+  const [touched, setTouched] = useState<{ email?: boolean }>({});
+
+  /** メールアドレスのバリデーションを実行してエラー状態を更新する */
+  const runEmailValidation = (email: string): boolean => {
+    const result = validateEmail(email);
+    setErrors((prev) => ({
+      ...prev,
+      email: result.valid ? undefined : result.message,
+    }));
+    return result.valid;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setValues((prev) => ({ ...prev, email: value }));
+    // touched 済みのフィールドはリアルタイムで再バリデーション
+    if (touched.email) {
+      runEmailValidation(value);
+    }
+  };
+
+  const handleBlur = () => {
+    setTouched((prev) => ({ ...prev, email: true }));
+    runEmailValidation(values.email);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setTouched({ email: true });
+    const isValid = runEmailValidation(values.email);
+    if (!isValid) return;
+    // TODO: 送信処理
+    alert(`登録メール: ${values.email}`);
+  };
+
+  const hasError = Boolean(errors.email);
+
+  return (
+    <form onSubmit={handleSubmit} noValidate>
+      <div style={{ marginBottom: "16px" }}>
+        <label htmlFor="email" style={{ display: "block", marginBottom: "4px" }}>
+          メールアドレス
+        </label>
+        <input
+          id="email"
+          type="email"
+          value={values.email}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          aria-invalid={hasError}
+          aria-describedby={hasError ? "email-error" : undefined}
+          style={{
+            border: `1px solid ${hasError ? "#e53e3e" : "#ccc"}`,
+            borderRadius: "4px",
+            padding: "8px 12px",
+            width: "100%",
+            boxSizing: "border-box",
+          }}
+        />
+        {hasError && (
+          <p
+            id="email-error"
+            role="alert"
+            style={{ color: "#e53e3e", fontSize: "0.875rem", marginTop: "4px" }}
+          >
+            {errors.email}
+          </p>
+        )}
+      </div>
+
+      <button
+        type="submit"
+        disabled={hasError}
+        style={{
+          backgroundColor: hasError ? "#a0aec0" : "#3182ce",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          padding: "8px 24px",
+          cursor: hasError ? "not-allowed" : "pointer",
+        }}
+      >
+        登録する
+      </button>
+    </form>
+  );
+}

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,0 +1,35 @@
+/**
+ * メールアドレスのバリデーション関数
+ * RFC 5322 準拠の正規表現でフォーマットチェックを行う
+ */
+
+export interface ValidationResult {
+  valid: boolean;
+  message?: string;
+}
+
+/**
+ * RFC 5322 準拠のメールアドレス正規表現
+ * - ローカルパート: 英数字・記号（ドット、ハイフン、アンダースコア、プラス）
+ * - @ 記号必須
+ * - ドメインパート: 英数字・ハイフン、ドット区切り
+ * - 連続するドットは不可
+ * - TLD は 2 文字以上
+ */
+const EMAIL_REGEX =
+  /^(?!.*\.{2})[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/;
+
+export function validateEmail(email: string): ValidationResult {
+  if (email.length === 0) {
+    return { valid: false, message: "メールアドレスを入力してください" };
+  }
+
+  if (!EMAIL_REGEX.test(email)) {
+    return {
+      valid: false,
+      message: "有効なメールアドレスの形式で入力してください",
+    };
+  }
+
+  return { valid: true };
+}

--- a/tests/RegisterForm.test.tsx
+++ b/tests/RegisterForm.test.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RegisterForm } from "../src/components/RegisterForm";
+
+describe("RegisterForm", () => {
+  // ── 正常系 ──────────────────────────────────────────────────
+  describe("正常系: 有効なメールアドレス入力", () => {
+    test("有効なメールアドレスを入力してもエラーが表示されない", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+
+      await userEvent.type(input, "user@example.com");
+      fireEvent.blur(input);
+
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    test("有効なメールアドレス入力後、送信ボタンが活性状態になる", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+      const button = screen.getByRole("button", { name: "登録する" });
+
+      await userEvent.type(input, "user@example.com");
+      fireEvent.blur(input);
+
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  // ── 異常系: フォーマット不正 ───────────────────────────────
+  describe("異常系: 不正なフォーマット", () => {
+    test("@ なしでフォーカスを外すとエラーメッセージが表示される", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+
+      await userEvent.type(input, "invalidemail");
+      fireEvent.blur(input);
+
+      expect(
+        screen.getByText("有効なメールアドレスの形式で入力してください")
+      ).toBeInTheDocument();
+    });
+
+    test("ドメインなしでフォーカスを外すとエラーメッセージが表示される", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+
+      await userEvent.type(input, "user@");
+      fireEvent.blur(input);
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "有効なメールアドレスの形式で入力してください"
+      );
+    });
+
+    test("連続ドットを含む場合にエラーメッセージが表示される", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+
+      await userEvent.type(input, "user..name@example.com");
+      fireEvent.blur(input);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
+  // ── 異常系: 空文字 ─────────────────────────────────────────
+  describe("異常系: 空文字入力", () => {
+    test("何も入力せずフォーカスを外すとエラーメッセージが表示される", () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+
+      fireEvent.blur(input);
+
+      expect(
+        screen.getByText("メールアドレスを入力してください")
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── UI: 送信ボタン非活性 ───────────────────────────────────
+  describe("UI: 送信ボタンの disabled 制御", () => {
+    test("エラーがある状態で送信ボタンが非活性になる", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+      const button = screen.getByRole("button", { name: "登録する" });
+
+      await userEvent.type(input, "bad-email");
+      fireEvent.blur(input);
+
+      expect(button).toBeDisabled();
+    });
+
+    test("エラーメッセージが表示されている状態で送信ボタンが非活性になる", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+      const button = screen.getByRole("button", { name: "登録する" });
+
+      await userEvent.type(input, "notanemail");
+      fireEvent.blur(input);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(button).toBeDisabled();
+    });
+  });
+
+  // ── UI: エラー解消 ─────────────────────────────────────────
+  describe("UI: 正しい形式に修正するとエラーが消える", () => {
+    test("不正な入力を修正して有効な形式にするとエラーが消える", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+
+      // 不正な入力 → エラー表示
+      await userEvent.type(input, "bad");
+      fireEvent.blur(input);
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // 有効な形式に修正
+      await userEvent.clear(input);
+      await userEvent.type(input, "valid@example.com");
+
+      expect(screen.queryByRole("alert")).toBeNull();
+    });
+
+    test("エラー修正後、送信ボタンが活性状態に戻る", async () => {
+      render(<RegisterForm />);
+      const input = screen.getByLabelText("メールアドレス");
+      const button = screen.getByRole("button", { name: "登録する" });
+
+      // 不正な入力
+      await userEvent.type(input, "bad");
+      fireEvent.blur(input);
+      expect(button).toBeDisabled();
+
+      // 有効な形式に修正
+      await userEvent.clear(input);
+      await userEvent.type(input, "valid@example.com");
+
+      expect(button).not.toBeDisabled();
+    });
+  });
+});

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,0 +1,60 @@
+import { validateEmail } from "../src/utils/validate";
+
+describe("validateEmail", () => {
+  // ── 正常系 ──────────────────────────────────────────────────
+  describe("正常系: 有効なメールアドレス", () => {
+    const validAddresses = [
+      "user@example.com",
+      "user.name@example.com",
+      "user+tag@example.co.jp",
+      "user-name@sub.example.org",
+      "user_name@example.io",
+      "123@example.com",
+    ];
+
+    test.each(validAddresses)('"%s" はエラーなし', (email) => {
+      const result = validateEmail(email);
+      expect(result.valid).toBe(true);
+      expect(result.message).toBeUndefined();
+    });
+  });
+
+  // ── 異常系: 空文字 ─────────────────────────────────────────
+  describe("異常系: 空文字", () => {
+    test("空文字のとき「入力してください」メッセージを返す", () => {
+      const result = validateEmail("");
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe("メールアドレスを入力してください");
+    });
+  });
+
+  // ── 異常系: フォーマット不正 ───────────────────────────────
+  describe("異常系: フォーマット不正", () => {
+    const invalidAddresses = [
+      // @ なし
+      ["userexample.com", "@ なし"],
+      // ドメインなし
+      ["user@", "ドメインなし"],
+      // TLD なし
+      ["user@example", "TLD なし"],
+      // 連続ドット (ローカルパート)
+      ["user..name@example.com", "ローカルパートに連続ドット"],
+      // 連続ドット (ドメイン)
+      ["user@ex..ample.com", "ドメインに連続ドット"],
+      // @ が複数
+      ["user@@example.com", "@ が複数"],
+      // ローカルパートなし
+      ["@example.com", "ローカルパートなし"],
+      // スペース含む
+      ["user name@example.com", "スペース含む"],
+    ];
+
+    test.each(invalidAddresses)("%s (%s) はエラーメッセージを返す", (email) => {
+      const result = validateEmail(email);
+      expect(result.valid).toBe(false);
+      expect(result.message).toBe(
+        "有効なメールアドレスの形式で入力してください"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 実装内容
Issue #7 の機能追加です。

## 実装方針 (承認済み)
---
📋 **実装方針 (AI提案)**

**変更内容:**
- `src/utils/validate.ts`: メールアドレスのバリデーション関数 `validateEmail(email: string): { valid: boolean; message?: string }` を追加。RFC 5322 準拠の正規表現でフォーマットチェックを実装
- `src/components/RegisterForm.tsx`: フォームの `onChange` / `onBlur` イベントで `validateEmail` を呼び出し、エラー時に入力フィールド下部にエラーメッセージを表示。送信ボタンはバリデーションエラーがある場合は `disabled` にする

**テスト方針:**
- [ ] 正常系: `user@example.com` など有効なメールアドレスでエラーが表示されないこと
- [ ] 異常系: `@` なし・ドメインなし・連続ドットなど不正な形式でエラーメッセージが表示されること
- [ ] 異常系: 空文字入力時にエラーが表示されること
- [ ] U

AI Agent が自動実装しました。