### PR TITLE
fix: UserProfileView で user が null の場合の TypeError を修正 (#59)

### DIFF
--- a/app/users/[id]/__tests__/page.test.tsx
+++ b/app/users/[id]/__tests__/page.test.tsx
@@ -62,6 +62,16 @@ describe('UserProfilePage', () => {
     });
   });
 
+  it('プロフィールが見つからない場合「ユーザーが見つかりません」が表示される', async () => {
+    mockGetUserProfile.mockResolvedValue(null as any);
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('ユーザーが見つかりません')).toBeInTheDocument();
+    });
+  });
+
   it('ローディング中は「読み込み中...」が表示される', () => {
     mockGetUserProfile.mockReturnValue(new Promise(() => {}));
 

--- a/src/components/UserProfileView.tsx
+++ b/src/components/UserProfileView.tsx
@@ -3,7 +3,7 @@ import { UserProfile } from '../types/user';
 import styles from './UserProfileView.module.css';
 
 interface UserProfileViewProps {
-  profile: UserProfile;
+  profile: UserProfile | null;
   editable: boolean;
   onEdit?: () => void;
 }
@@ -13,6 +13,14 @@ export const UserProfileView: React.FC<UserProfileViewProps> = ({
   editable,
   onEdit,
 }) => {
+  if (!profile) {
+    return (
+      <div className={styles.container}>
+        <p>ユーザーが見つかりません</p>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>

--- a/src/components/__tests__/UserProfileView.test.tsx
+++ b/src/components/__tests__/UserProfileView.test.tsx
@@ -79,6 +79,20 @@ describe('UserProfileView', () => {
     expect(screen.queryByText('プロフィールを編集')).not.toBeInTheDocument();
   });
 
+  it('profile が null の場合「ユーザーが見つかりません」が表示される', () => {
+    render(
+      <UserProfileView profile={null} editable={false} />
+    );
+    expect(screen.getByText('ユーザーが見つかりません')).toBeInTheDocument();
+  });
+
+  it('profile が null の場合に編集ボタンが表示されない', () => {
+    render(
+      <UserProfileView profile={null} editable={true} onEdit={jest.fn()} />
+    );
+    expect(screen.queryByText('プロフィールを編集')).not.toBeInTheDocument();
+  });
+
   it('編集ボタンクリックで onEdit が呼ばれる', () => {
     const onEdit = jest.fn();
     render(


### PR DESCRIPTION
## 概要

`UserProfileView` コンポーネントに `user` prop が `null` または `undefined` の場合に発生する `TypeError: Cannot read properties of null (reading 'name')` を修正しました。

Closes #59

## 修正内容

### 1. `src/components/UserProfileView.tsx` — null ガードの追加
- `profile` props の型を `UserProfile` → `UserProfile | null` に変更
- `profile` が `null` の場合、「ユーザーが見つかりません」メッセージを表示する早期リターンを追加

### 2. `src/components/__tests__/UserProfileView.test.tsx` — テスト追加
- `profile` が `null` の場合に「ユーザーが見つかりません」が表示されるテスト
- `profile` が `null` の場合に編集ボタンが表示されないテスト

### 3. `app/users/[id]/__tests__/page.test.tsx` — テスト追加
- `getUserProfile` が `null` を返した場合に「ユーザーが見つかりません」が表示されるテスト

## 修正方針

### バグの原因分析

`UserProfileView` コンポーネントの props 型定義で `profile` が必須（non-nullable）として定義されており、コンポーネント内部では `profile.name`、`profile.email`、`profile.avatarUrl` 等に直接アクセスしていたため、`null` が渡された場合に TypeError が発生していた。

| レイヤー | ファイル | null ガード | 状態 |
|---|---|---|---|
| ページ（呼び出し側） | `app/users/[id]/page.tsx` | `if (!profile) return <div>ユーザーが見つかりません</div>;` | ✅ 対応済み |
| フック | `src/hooks/useUserProfile.ts` | `useState<UserProfile \| null>(null)` | ✅ null を返しうる |
| コンポーネント | `src/components/UserProfileView.tsx` | なし → **追加** | ✅ 修正済み |

### 修正方針の詳細

- **防御的プログラミング**: `profile` の型を `UserProfile | null` に拡張し、`null` の場合は「ユーザーが見つかりません」メッセージを表示
- **後方互換性あり**: `UserProfile` は `UserProfile | null` の部分型であり、既存の呼び出し元に影響なし
- **スコープ外**: Error Boundary の追加、`useUserProfile` フックの修正、API クライアントの修正は別 Issue で対応

## テスト計画

- [x] 既存テスト全44件が合格することを確認
- [x] 新規追加テスト（null ガード）3件が合格することを確認
- [ ] 手動確認: `/users/999`（存在しないID）にアクセスし、白い画面ではなく「ユーザーが見つかりません」が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)