### PR TITLE
fix: UserCard で name が空文字の場合にフォールバック表示を追加 (#63)

### DIFF
--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -9,8 +9,8 @@ interface UserCardProps {
 export const UserCard: React.FC<UserCardProps> = ({ user, onClick }) => {
   return (
     <div className="user-card" onClick={() => onClick?.(user)}>
-      <img src={user.avatarUrl || '/default-avatar.png'} alt={user.name} />
-      <h3>{user.name}</h3>
+      <img src={user.avatarUrl || '/default-avatar.png'} alt={user.name || '名前未設定'} />
+      <h3>{user.name || '名前未設定'}</h3>
       <p>{user.email}</p>
     </div>
   );

--- a/src/components/__tests__/UserCard.test.tsx
+++ b/src/components/__tests__/UserCard.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UserCard } from '../UserCard';
+import { User } from '../../types/user';
+
+const mockUser: User = {
+  id: 'user-1',
+  name: 'テストユーザー',
+  email: 'test@example.com',
+  avatarUrl: 'https://example.com/avatar.png',
+  createdAt: new Date('2024-01-01'),
+};
+
+describe('UserCard', () => {
+  it('正常な name が表示される', () => {
+    render(<UserCard user={mockUser} />);
+
+    expect(screen.getByText('テストユーザー')).toBeInTheDocument();
+  });
+
+  it('name が空文字の場合にフォールバック表示される', () => {
+    const userWithEmptyName: User = { ...mockUser, name: '' };
+    render(<UserCard user={userWithEmptyName} />);
+
+    expect(screen.getByText('名前未設定')).toBeInTheDocument();
+  });
+
+  it('email が表示される', () => {
+    render(<UserCard user={mockUser} />);
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('avatarUrl が未指定の場合にデフォルト画像が使用される', () => {
+    const userWithoutAvatar: User = { ...mockUser, avatarUrl: undefined };
+    render(<UserCard user={userWithoutAvatar} />);
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', '/default-avatar.png');
+  });
+
+  it('onClick が呼ばれる', () => {
+    const mockOnClick = jest.fn();
+    render(<UserCard user={mockUser} onClick={mockOnClick} />);
+
+    fireEvent.click(screen.getByText('テストユーザー'));
+
+    expect(mockOnClick).toHaveBeenCalledWith(mockUser);
+  });
+
+  it('onClick が未指定でもエラーにならない', () => {
+    expect(() => {
+      render(<UserCard user={mockUser} />);
+      fireEvent.click(screen.getByText('テストユーザー'));
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- `UserCard` コンポーネントで `user.name` が空文字の場合に「名前未設定」をフォールバック表示するよう修正
- `img` の `alt` 属性にも同様のフォールバックを追加（アクセシビリティ改善）
- `UserCard` のユニットテストを新規作成（6ケース、全通過）

Closes #63

## 修正内容

### `src/components/UserCard.tsx`

**変更前**:
```tsx
<img src={user.avatarUrl || '/default-avatar.png'} alt={user.name} />
<h3>{user.name}</h3>
```

**変更後**:
```tsx
<img src={user.avatarUrl || '/default-avatar.png'} alt={user.name || '名前未設定'} />
<h3>{user.name || '名前未設定'}</h3>
```

### `src/components/__tests__/UserCard.test.tsx` (新規)

| # | テストケース | 結果 |
|---|---|---|
| 1 | 正常な name が表示される | ✅ |
| 2 | name が空文字の場合にフォールバック表示される | ✅ |
| 3 | email が表示される | ✅ |
| 4 | avatarUrl が未指定の場合にデフォルト画像が使用される | ✅ |
| 5 | onClick が呼ばれる | ✅ |
| 6 | onClick が未指定でもエラーにならない | ✅ |

## 修正方針

### 問題分析

`UserCard.tsx` の `<h3>{user.name}</h3>` で、`user.name` が空文字 `''` の場合に JSX はそのまま空文字を描画し、`<h3></h3>` という空要素が出力される。同様に `alt` 属性も空文字になりアクセシビリティ上も問題がある。

### 設計判断

- `avatarUrl` で既に `||` によるフォールバックパターンが使われており、同じパターンに統一
- フォールバック文字列は「名前未設定」（Issue の期待動作に記載のとおり）
- 論理OR (`||`) を使い、falsy な値（`''`, `undefined`, `null`）すべてに対応
- 定数化は行わない（現時点では1箇所のみの使用であり、過度な抽象化を避ける）

## Test plan
- [x] `UserCard` のユニットテスト 6ケース全通過
- [x] 既存テスト全50ケース通過（リグレッションなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)