### PR TITLE
fix: website URLにプロトコルが無い場合にリンクが壊れるバグを修正 (#76)

### DIFF
--- a/src/components/UserProfileView.tsx
+++ b/src/components/UserProfileView.tsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { UserProfile } from '../types/user';
 import styles from './UserProfileView.module.css';
 
+function ensureProtocol(url: string): string {
+  if (/^https?:\/\//i.test(url)) {
+    return url;
+  }
+  return `https://${url}`;
+}
+
 interface UserProfileViewProps {
   profile: UserProfile | null | undefined;
   editable: boolean;
@@ -53,7 +60,7 @@ export const UserProfileView: React.FC<UserProfileViewProps> = ({
         <div className={styles.section}>
           <div className={styles.label}>Webサイト</div>
           <p className={styles.value}>
-            <a href={profile.website} target="_blank" rel="noopener noreferrer">
+            <a href={ensureProtocol(profile.website)} target="_blank" rel="noopener noreferrer">
               {profile.website}
             </a>
           </p>

--- a/src/components/__tests__/UserProfileView.test.tsx
+++ b/src/components/__tests__/UserProfileView.test.tsx
@@ -93,6 +93,41 @@ describe('UserProfileView', () => {
     expect(screen.getByText('ユーザーが見つかりません')).toBeInTheDocument();
   });
 
+  it('プロトコル無しURLに https:// が補完される', () => {
+    const profileWithoutProtocol: UserProfile = {
+      ...fullProfile,
+      website: 'example.com',
+    };
+    render(
+      <UserProfileView profile={profileWithoutProtocol} editable={false} />
+    );
+
+    const link = screen.getByText('example.com');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('https:// 付きURLはそのまま', () => {
+    render(
+      <UserProfileView profile={fullProfile} editable={false} />
+    );
+
+    const link = screen.getByText('https://example.com');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('http:// 付きURLはそのまま', () => {
+    const profileWithHttp: UserProfile = {
+      ...fullProfile,
+      website: 'http://example.com',
+    };
+    render(
+      <UserProfileView profile={profileWithHttp} editable={false} />
+    );
+
+    const link = screen.getByText('http://example.com');
+    expect(link).toHaveAttribute('href', 'http://example.com');
+  });
+
   it('編集ボタンクリックで onEdit が呼ばれる', () => {
     const onEdit = jest.fn();
     render(


### PR DESCRIPTION
## 概要
UserProfileView コンポーネントで `profile.website` がプロトコル（`https://`）を含まない場合に、相対パスとして解釈されてリンクが壊れるバグを修正しました。

Closes #76

## 変更内容
- `src/components/UserProfileView.tsx` に `ensureProtocol` ヘルパー関数を追加
- `<a href>` 属性にヘルパー関数を適用し、プロトコル無しURLには `https://` を自動補完
- テストケース3件を追加（プロトコル無し / https付き / http付き）

## 修正方針

### 原因分析
`UserProfileView.tsx` の `<a href={profile.website}>` で、`profile.website` が `"example.com"` のようにプロトコルを含まない場合、ブラウザが相対パスとして解釈してしまう。

### 修正内容

#### ヘルパー関数の追加
```ts
function ensureProtocol(url: string): string {
  if (/^https?:\/\//i.test(url)) {
    return url;
  }
  return `https://${url}`;
}
```

- `http://` または `https://` が既に付いている場合はそのまま返す
- プロトコルが無い場合は `https://` を付与（セキュリティ上 `https` をデフォルト）
- 表示テキストは元の `profile.website` のまま変更なし

#### テストケース

| # | テストケース | `profile.website` | 期待する `href` |
|---|-------------|-------------------|-----------------|
| 1 | プロトコル無しURLに `https://` が補完される | `"example.com"` | `"https://example.com"` |
| 2 | `https://` 付きURLはそのまま | `"https://example.com"` | `"https://example.com"` |
| 3 | `http://` 付きURLはそのまま | `"http://example.com"` | `"http://example.com"` |

## 影響範囲
- **変更スコープ:** `UserProfileView` コンポーネントのみ
- **既存テスト:** 全53テスト通過確認済み
- **`ProfileEditForm.tsx`:** 入力フォーム側の変更不要（表示側で吸収）
- **型定義:** 変更不要

## テスト計画
- [x] プロトコル無しURLに `https://` が補完されることを確認
- [x] `https://` 付きURLがそのまま保持されることを確認
- [x] `http://` 付きURLがそのまま保持されることを確認
- [x] 既存テスト全件通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)