### PR TITLE
fix: NotificationSettingsFormでpropsの変更が内部stateに反映されない問題を修正

### DIFF
--- a/src/components/NotificationSettingsForm.tsx
+++ b/src/components/NotificationSettingsForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { NotificationSettings, NotificationFrequency, FREQUENCY_LABELS } from '../types/notification';
 import styles from './NotificationSettingsForm.module.css';
 
@@ -16,6 +16,13 @@ export const NotificationSettingsForm: React.FC<NotificationSettingsFormProps> =
   const [emailEnabled, setEmailEnabled] = useState(settings.emailEnabled);
   const [pushEnabled, setPushEnabled] = useState(settings.pushEnabled);
   const [frequency, setFrequency] = useState<NotificationFrequency>(settings.frequency);
+
+  useEffect(() => {
+    setEmailEnabled(settings.emailEnabled);
+    setPushEnabled(settings.pushEnabled);
+    setFrequency(settings.frequency);
+  }, [settings.emailEnabled, settings.pushEnabled, settings.frequency]);
+
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);

--- a/src/components/__tests__/NotificationSettingsForm.test.tsx
+++ b/src/components/__tests__/NotificationSettingsForm.test.tsx
@@ -100,6 +100,26 @@ describe('NotificationSettingsForm', () => {
     });
   });
 
+  it('親コンポーネントからのprops変更がフォームに反映される', () => {
+    const { rerender } = render(
+      <NotificationSettingsForm settings={mockSettings} onSave={mockOnSave} />
+    );
+
+    const updatedSettings: NotificationSettings = {
+      emailEnabled: false,
+      pushEnabled: false,
+      frequency: 'weekly',
+    };
+
+    rerender(
+      <NotificationSettingsForm settings={updatedSettings} onSave={mockOnSave} />
+    );
+
+    expect(screen.getByLabelText('メール通知')).not.toBeChecked();
+    expect(screen.getByLabelText('プッシュ通知')).not.toBeChecked();
+    expect(screen.getByLabelText('通知頻度')).toHaveValue('weekly');
+  });
+
   it('保存成功時に成功メッセージが表示される', async () => {
     render(<NotificationSettingsForm settings={mockSettings} onSave={mockOnSave} />);
 
@@ -108,5 +128,51 @@ describe('NotificationSettingsForm', () => {
     await waitFor(() => {
       expect(screen.getByText('設定を保存しました')).toBeInTheDocument();
     });
+  });
+
+  it('props変更後に保存すると更新された値でonSaveが呼ばれる', async () => {
+    const { rerender } = render(
+      <NotificationSettingsForm settings={mockSettings} onSave={mockOnSave} />
+    );
+
+    const updatedSettings: NotificationSettings = {
+      emailEnabled: false,
+      pushEnabled: false,
+      frequency: 'daily',
+    };
+
+    rerender(
+      <NotificationSettingsForm settings={updatedSettings} onSave={mockOnSave} />
+    );
+
+    fireEvent.submit(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalledWith({
+        emailEnabled: false,
+        pushEnabled: false,
+        frequency: 'daily',
+      });
+    });
+  });
+
+  it('一部のpropsのみ変更された場合も正しく反映される', () => {
+    const { rerender } = render(
+      <NotificationSettingsForm settings={mockSettings} onSave={mockOnSave} />
+    );
+
+    const partiallyUpdatedSettings: NotificationSettings = {
+      emailEnabled: false,
+      pushEnabled: true,
+      frequency: 'immediate',
+    };
+
+    rerender(
+      <NotificationSettingsForm settings={partiallyUpdatedSettings} onSave={mockOnSave} />
+    );
+
+    expect(screen.getByLabelText('メール通知')).not.toBeChecked();
+    expect(screen.getByLabelText('プッシュ通知')).toBeChecked();
+    expect(screen.getByLabelText('通知頻度')).toHaveValue('immediate');
   });
 });


### PR DESCRIPTION
## Summary
- `NotificationSettingsForm` コンポーネントで、親コンポーネントからの `settings` prop 変更が内部 state に反映されないバグを修正
- `useEffect` を追加して `settings` prop → 内部 state の同期を実現
- props 変更時のフォーム更新テスト、一部 props 変更テスト、props 変更後の保存テストを追加

Closes #79

## 修正方針

### 原因分析
`NotificationSettingsForm.tsx` (L16-18) で、`settings` prop を `useState` の**初期値**としてのみ使用していた。React の `useState` は初期値を初回レンダリング時にのみ評価するため、親コンポーネントから `settings` prop が変更されても内部 state は更新されなかった。

### 修正内容

| ファイル | 変更内容 |
|---|---|
| `src/components/NotificationSettingsForm.tsx` | `useEffect` を追加して `settings` prop → 内部 state の同期 |
| `src/components/__tests__/NotificationSettingsForm.test.tsx` | props 変更時のフォーム更新テストを追加 |

**`NotificationSettingsForm.tsx`** に以下の `useEffect` を追加:
```tsx
useEffect(() => {
  setEmailEnabled(settings.emailEnabled);
  setPushEnabled(settings.pushEnabled);
  setFrequency(settings.frequency);
}, [settings.emailEnabled, settings.pushEnabled, settings.frequency]);
```

依存配列には `settings` オブジェクト全体ではなく個別のプロパティを指定し、親コンポーネントで `settings` オブジェクトの参照が変わっただけ（値は同一）の場合に不要な state リセットを防止。

### 代替案の検討と却下理由
| 代替案 | 却下理由 |
|---|---|
| `key` prop によるコンポーネント再マウント | ユーザーの未保存入力やフォーカス状態が失われる |
| 内部 state を廃止し props を直接参照 | `onSave` が非同期のため内部 state が必要。親コンポーネント側の大幅改修も必要 |

### 注意事項
`ProfileEditForm.tsx` にも同様の問題が存在するが、本 Issue のスコープ外のため別 Issue での対応を推奨。

## Test plan
- [x] props 変更がフォームに反映されるテスト
- [x] 一部の props のみ変更された場合のテスト
- [x] props 変更後に保存すると更新された値で onSave が呼ばれるテスト
- [x] 既存テストがすべてパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)