### PR TITLE
fix: 保存成功メッセージが消えないバグを修正 (#81)

### DIFF
--- a/src/components/NotificationSettingsForm.tsx
+++ b/src/components/NotificationSettingsForm.tsx
@@ -27,6 +27,15 @@ export const NotificationSettingsForm: React.FC<NotificationSettingsFormProps> =
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
+  useEffect(() => {
+    if (saveSuccess) {
+      const timer = setTimeout(() => {
+        setSaveSuccess(false);
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [saveSuccess]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSaving(true);
@@ -58,7 +67,7 @@ export const NotificationSettingsForm: React.FC<NotificationSettingsFormProps> =
           type="checkbox"
           role="switch"
           checked={emailEnabled}
-          onChange={(e) => setEmailEnabled(e.target.checked)}
+          onChange={(e) => { setEmailEnabled(e.target.checked); setSaveSuccess(false); }}
         />
       </div>
 
@@ -74,7 +83,7 @@ export const NotificationSettingsForm: React.FC<NotificationSettingsFormProps> =
           type="checkbox"
           role="switch"
           checked={pushEnabled}
-          onChange={(e) => setPushEnabled(e.target.checked)}
+          onChange={(e) => { setPushEnabled(e.target.checked); setSaveSuccess(false); }}
         />
       </div>
 
@@ -85,7 +94,7 @@ export const NotificationSettingsForm: React.FC<NotificationSettingsFormProps> =
         <select
           id="frequency"
           value={frequency}
-          onChange={(e) => setFrequency(e.target.value as NotificationFrequency)}
+          onChange={(e) => { setFrequency(e.target.value as NotificationFrequency); setSaveSuccess(false); }}
         >
           {(Object.entries(FREQUENCY_LABELS) as [NotificationFrequency, string][]).map(
             ([value, label]) => (

--- a/src/components/__tests__/NotificationSettingsForm.test.tsx
+++ b/src/components/__tests__/NotificationSettingsForm.test.tsx
@@ -156,6 +156,52 @@ describe('NotificationSettingsForm', () => {
     });
   });
 
+  it('保存成功メッセージが3秒後に自動で消える', async () => {
+    jest.useFakeTimers();
+    render(<NotificationSettingsForm settings={mockSettings} onSave={mockOnSave} />);
+
+    fireEvent.submit(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('設定を保存しました')).toBeInTheDocument();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(screen.queryByText('設定を保存しました')).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+
+  it('設定変更時に成功メッセージが消える（チェックボックス）', async () => {
+    render(<NotificationSettingsForm settings={mockSettings} onSave={mockOnSave} />);
+
+    fireEvent.submit(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('設定を保存しました')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByLabelText('メール通知'));
+
+    expect(screen.queryByText('設定を保存しました')).not.toBeInTheDocument();
+  });
+
+  it('設定変更時に成功メッセージが消える（セレクト）', async () => {
+    render(<NotificationSettingsForm settings={mockSettings} onSave={mockOnSave} />);
+
+    fireEvent.submit(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('設定を保存しました')).toBeInTheDocument();
+    });
+
+    await userEvent.selectOptions(screen.getByLabelText('通知頻度'), 'daily');
+
+    expect(screen.queryByText('設定を保存しました')).not.toBeInTheDocument();
+  });
+
   it('一部のpropsのみ変更された場合も正しく反映される', () => {
     const { rerender } = render(
       <NotificationSettingsForm settings={mockSettings} onSave={mockOnSave} />


### PR DESCRIPTION
## Summary
- NotificationSettingsFormで保存成功メッセージが永続的に表示され続けるバグを修正
- タイマーによる3秒後の自動消去とフォーム操作時の即時消去の2段構えで対応
- テストケースを3件追加（自動消去・チェックボックス操作時消去・セレクト操作時消去）

## 修正方針

Closes #81

### 原因分析
`src/components/NotificationSettingsForm.tsx` の `handleSubmit` 内で `setSaveSuccess(true)` を呼んだ後、`saveSuccess` を `false` に戻す処理が存在しなかった。次回の `handleSubmit` 呼び出し時でのみリセットされるため、保存操作を再度行わない限りメッセージが永続表示されていた。

### 修正内容

**修正A: `useEffect` で成功メッセージを3秒後に自動消去**
```tsx
useEffect(() => {
  if (saveSuccess) {
    const timer = setTimeout(() => {
      setSaveSuccess(false);
    }, 3000);
    return () => clearTimeout(timer);
  }
}, [saveSuccess]);
```

**修正B: フォーム操作時に即座に消去**
各入力フィールドの `onChange` に `setSaveSuccess(false)` を追加。

### 修正対象ファイル
| ファイル | 変更内容 |
|---|---|
| `src/components/NotificationSettingsForm.tsx` | `useEffect` によるタイマー追加 + 各 `onChange` での `setSaveSuccess(false)` 追加 |
| `src/components/__tests__/NotificationSettingsForm.test.tsx` | 自動消去・操作時消去のテストケース3件追加 |

## Test plan
- [x] 保存成功メッセージが3秒後に自動で消えるテスト
- [x] チェックボックス操作時に成功メッセージが消えるテスト
- [x] セレクト操作時に成功メッセージが消えるテスト
- [x] 既存テスト14件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)