### PR TITLE
fix: bioフィールドの文字数制限を200文字に修正 (#101)

### DIFF
--- a/src/components/ProfileEditForm.module.css
+++ b/src/components/ProfileEditForm.module.css
@@ -41,6 +41,18 @@
   margin-top: 4px;
 }
 
+.charCount {
+  text-align: right;
+  font-size: 12px;
+  color: #888;
+  margin-top: 4px;
+}
+
+.charCountWarning {
+  color: #e00;
+  font-weight: bold;
+}
+
 .readOnly {
   color: #888;
   font-size: 14px;

--- a/src/components/ProfileEditForm.tsx
+++ b/src/components/ProfileEditForm.tsx
@@ -4,6 +4,8 @@ import React, { useState } from 'react';
 import { UserProfile } from '../types/user';
 import styles from './ProfileEditForm.module.css';
 
+const BIO_MAX_LENGTH = 200;
+
 interface ProfileEditFormProps {
   profile: UserProfile;
   onSave: (data: Partial<UserProfile>) => Promise<void>;
@@ -35,8 +37,8 @@ export const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
     if (!name.trim()) {
       newErrors.name = '名前は必須です';
     }
-    if (bio.length > 500) {
-      newErrors.bio = '自己紹介は500文字以内で入力してください';
+    if (bio.length > BIO_MAX_LENGTH) {
+      newErrors.bio = `自己紹介は${BIO_MAX_LENGTH}文字以内で入力してください`;
     }
     if (location.length > 100) {
       newErrors.location = '所在地は100文字以内で入力してください';
@@ -97,8 +99,14 @@ export const ProfileEditForm: React.FC<ProfileEditFormProps> = ({
           id="bio"
           value={bio}
           onChange={(e) => setBio(e.target.value)}
-          maxLength={500}
+          maxLength={BIO_MAX_LENGTH}
         />
+        <div
+          className={`${styles.charCount} ${bio.length > BIO_MAX_LENGTH - 20 ? styles.charCountWarning : ''}`}
+          data-testid="bio-char-count"
+        >
+          {bio.length}/{BIO_MAX_LENGTH}
+        </div>
         {errors.bio && <div className={styles.fieldError}>{errors.bio}</div>}
       </div>
 

--- a/src/components/__tests__/ProfileEditForm.test.tsx
+++ b/src/components/__tests__/ProfileEditForm.test.tsx
@@ -148,6 +148,61 @@ describe('ProfileEditForm', () => {
     expect(mockOnCancel).toHaveBeenCalledTimes(1);
   });
 
+  it('bio の文字数カウンターが表示される', () => {
+    render(
+      <ProfileEditForm
+        profile={mockProfile}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const charCount = screen.getByTestId('bio-char-count');
+    expect(charCount).toBeInTheDocument();
+    expect(charCount).toHaveTextContent('7/200');
+  });
+
+  it('bio が200文字を超える場合にバリデーションエラーが表示される', async () => {
+    render(
+      <ProfileEditForm
+        profile={{ ...mockProfile, bio: '' }}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const bioTextarea = screen.getByLabelText('自己紹介');
+    // fireEvent.change で maxLength をバイパスして201文字をセット
+    fireEvent.change(bioTextarea, { target: { value: 'あ'.repeat(201) } });
+
+    fireEvent.submit(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('自己紹介は200文字以内で入力してください')).toBeInTheDocument();
+    });
+
+    expect(mockOnSave).not.toHaveBeenCalled();
+  });
+
+  it('bio が200文字ちょうどの場合は保存できる', async () => {
+    render(
+      <ProfileEditForm
+        profile={{ ...mockProfile, bio: '' }}
+        onSave={mockOnSave}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const bioTextarea = screen.getByLabelText('自己紹介');
+    fireEvent.change(bioTextarea, { target: { value: 'あ'.repeat(200) } });
+
+    fireEvent.submit(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(mockOnSave).toHaveBeenCalled();
+    });
+  });
+
   it('保存中はボタンが無効化される', async () => {
     let resolveOnSave: () => void;
     mockOnSave.mockImplementation(


### PR DESCRIPTION
## Summary
- ProfileEditFormのbioフィールドの文字数制限を500文字から200文字に修正
- リアルタイム文字数カウンターを追加（残り20文字以下で警告色表示）
- バリデーション、境界値テストを追加

## 修正方針

### 現状の問題
| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| `validate()` 関数 | `bio.length > 500` | `bio.length > BIO_MAX_LENGTH` (200) |
| `<textarea>` の `maxLength` | `maxLength={500}` | `maxLength={BIO_MAX_LENGTH}` |
| 文字数カウンター | 未実装 | `{bio.length}/{BIO_MAX_LENGTH}` を表示 |
| 警告表示 | なし | 残り20文字以下で赤色表示 |

### 修正内容

#### 1. `src/components/ProfileEditForm.tsx`
- `BIO_MAX_LENGTH = 200` 定数を定義
- `validate()` のバリデーション閾値を200文字に変更
- `<textarea>` の `maxLength` を200に変更
- 文字数カウンター (`data-testid="bio-char-count"`) を追加
- 残り20文字以下で `charCountWarning` スタイルを適用

#### 2. `src/components/ProfileEditForm.module.css`
- `.charCount` スタイル追加（右寄せ、12px、グレー）
- `.charCountWarning` スタイル追加（赤色、太字）

#### 3. `src/components/__tests__/ProfileEditForm.test.tsx`
- `bio の文字数カウンターが表示される` — カウンター要素と初期表示 (`7/200`) の確認
- `bio が200文字を超える場合にバリデーションエラーが表示される` — 201文字入力→エラー表示 & `onSave` 未呼び出し
- `bio が200文字ちょうどの場合は保存できる` — 境界値テスト、200文字で `onSave` 呼び出し確認

### 対象外（スコープ外）
- バックエンド/API側のバリデーション（別Issue対応）
- `UserProfile` 型の変更（文字数制限はUI/バリデーション層の責務）
- 他フィールド（location等）の制限値見直し

## Test plan
- [x] `bio の文字数カウンターが表示される` テストがパス
- [x] `bio が200文字を超える場合にバリデーションエラーが表示される` テストがパス
- [x] `bio が200文字ちょうどの場合は保存できる` テストがパス
- [x] 既存テスト11件すべてパス

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)