### PR TITLE
fix: getUser等のID空文字時に不正URLへリクエストされるバグを修正 (#110)

### DIFF
--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -1,0 +1,53 @@
+import { getUser, getUserProfile, updateUser, updateUserProfile } from '../client';
+
+// global.fetch をモック化
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({}),
+  });
+});
+
+describe('IDバリデーション', () => {
+  describe('getUser', () => {
+    it('空文字を渡すとエラーがthrowされる', async () => {
+      await expect(getUser('')).rejects.toThrow('User ID is required');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('空白のみの文字列を渡すとエラーがthrowされる', async () => {
+      await expect(getUser('   ')).rejects.toThrow('User ID is required');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('正常なIDを渡すとfetchが正しいURLで呼び出される', async () => {
+      await getUser('user-1');
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/api/users/user-1');
+    });
+  });
+
+  describe('getUserProfile', () => {
+    it('空文字を渡すとエラーがthrowされる', async () => {
+      await expect(getUserProfile('')).rejects.toThrow('User ID is required');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateUser', () => {
+    it('空文字を渡すとエラーがthrowされる', async () => {
+      await expect(updateUser('', { name: 'test' })).rejects.toThrow('User ID is required');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateUserProfile', () => {
+    it('空文字を渡すとエラーがthrowされる', async () => {
+      await expect(updateUserProfile('', { bio: 'test' })).rejects.toThrow('User ID is required');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,19 +2,28 @@ import { User, UserProfile } from '../types/user';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000/api';
 
+function validateUserId(id: string): void {
+  if (!id || id.trim() === '') {
+    throw new Error('User ID is required');
+  }
+}
+
 export async function getUser(id: string): Promise<User> {
+  validateUserId(id);
   const res = await fetch(`${API_BASE}/users/${id}`);
   if (!res.ok) throw new Error(`Failed to fetch user: ${res.status}`);
   return res.json();
 }
 
 export async function getUserProfile(id: string): Promise<UserProfile> {
+  validateUserId(id);
   const res = await fetch(`${API_BASE}/users/${id}/profile`);
   if (!res.ok) throw new Error(`Failed to fetch profile: ${res.status}`);
   return res.json();
 }
 
 export async function updateUser(id: string, data: Partial<User>): Promise<User> {
+  validateUserId(id);
   const res = await fetch(`${API_BASE}/users/${id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
@@ -28,6 +37,7 @@ export async function updateUserProfile(
   id: string,
   data: Partial<UserProfile>
 ): Promise<UserProfile> {
+  validateUserId(id);
   const res = await fetch(`${API_BASE}/users/${id}/profile`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## 概要
`src/api/client.ts` の `getUser`, `getUserProfile`, `updateUser`, `updateUserProfile` に空文字のIDを渡すと不正なURLにリクエストが送信されるバグを修正しました。

Closes #110

## 変更内容
- `validateUserId` ヘルパー関数を追加し、4つの関数の先頭でIDバリデーションを実施
- 空文字・空白のみのIDが渡された場合は `fetch` 実行前に `Error('User ID is required')` をthrow
- ユニットテストを新規作成（6テストケース）

## 変更ファイル
| ファイル | 変更種別 | 内容 |
|---------|---------|------|
| `src/api/client.ts` | 変更 | `validateUserId` 追加、4関数にバリデーション挿入 |
| `src/api/__tests__/client.test.ts` | 新規 | IDバリデーションのユニットテスト |

## テスト結果
全72テスト（既存66 + 新規6）がパスすることを確認済み。

## 修正方針

### 問題の分析
`src/api/client.ts` の4つの関数は `id` パラメータに対するバリデーションを一切行っていないため、空文字 `""` や空白のみの文字列が渡された場合に不正なURL（`/api/users/` や `/api/users//profile`）が生成される。

### バリデーションルール
| チェック項目 | 条件 | エラーメッセージ |
|------------|------|----------------|
| Falsy チェック | `!id` (undefined, null, 空文字) | `User ID is required` |
| 空白のみ | `id.trim() === ''` | `User ID is required` |

### 実装方針
- `validateUserId` ヘルパー関数を追加し、4つの関数の先頭でガード
- fetch を実行する前に同期的にエラーを throw
- hooks層（`useUser.ts`, `useUserProfile.ts`）は既存の `catch(setError)` でエラーハンドリング済みのため変更不要

## テスト方針
- `global.fetch` をモック化
- バリデーションエラー時に `fetch` が呼び出されないことを検証
- 正常なIDの場合は正しいURLで `fetch` が呼び出されることを検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)